### PR TITLE
20211201#5 feat

### DIFF
--- a/TimeStampNote/Models/Comment.cs
+++ b/TimeStampNote/Models/Comment.cs
@@ -41,6 +41,9 @@
         [Column("deleted")]
         public bool Deleted { get; set; }
 
+        [NotMapped]
+        public bool IsSelected { get; set; }
+
         /// <summary>
         /// SubID 用の文字列を生成し、SubID にセットします。
         /// </summary>

--- a/TimeStampNote/Models/CommentDbContext.cs
+++ b/TimeStampNote/Models/CommentDbContext.cs
@@ -45,6 +45,11 @@
             return Comments.Where(c => c.SubID.IndexOf(partyOfSubID, StringComparison.OrdinalIgnoreCase) != -1).ToList();
         }
 
+        public List<Comment> GetCommentByOrderIndex(string groupName, int orderNumber)
+        {
+            return Comments.Where(c => c.GroupName == groupName && c.OrderNumber == orderNumber).ToList();
+        }
+
         public Comment GetLatastCommentFromSubID(string partOfSubID)
         {
             var list = Comments.Where(c => c.SubID.IndexOf(partOfSubID, StringComparison.OrdinalIgnoreCase) != -1)

--- a/TimeStampNote/ViewModels/MainWindowViewModel.cs
+++ b/TimeStampNote/ViewModels/MainWindowViewModel.cs
@@ -54,6 +54,8 @@
 
         public ObservableCollection<Comment> Comments { get; private set; } = new ObservableCollection<Comment>();
 
+        public ObservableCollection<Comment> SelectedComments { get; private set; } = new ObservableCollection<Comment>();
+
         public ObservableCollection<string> GroupNames { get; private set; } = new ObservableCollection<string>();
 
         public string CommandText

--- a/TimeStampNote/ViewModels/MainWindowViewModel.cs
+++ b/TimeStampNote/ViewModels/MainWindowViewModel.cs
@@ -21,6 +21,7 @@
         private DelegateCommand executeCommandCommand;
         private DelegateCommand getCommentCommand;
         private DelegateCommand reloadGroupNamesCommand;
+        private DelegateCommand reverseOrderCommand;
         private DelegateCommand<string> toggleVisibilityCommand;
         private DelegateCommand toLigthThemeCommand;
         private DelegateCommand toDarkThemeCommand;
@@ -159,6 +160,13 @@
                 AddGroupCommand.Execute();
             }
 
+            if (Regex.IsMatch(CommandText, "^reverse-?order", regOption))
+            {
+                ReverseOrderCommand.Execute();
+                CommandText = string.Empty;
+                return;
+            }
+
             if (Regex.IsMatch(CommandText, "^(e|edit) .+", regOption))
             {
                 EditCommentCommand.Execute(Regex.Matches(CommandText, "^(e|edit) (.*)", regOption)[0].Groups[2].Value);
@@ -190,6 +198,15 @@
             GroupNames.Clear();
             GroupNames.AddRange(DbContext.GetGroupNames());
         }));
+
+        public DelegateCommand ReverseOrderCommand
+        {
+            get => reverseOrderCommand ?? (reverseOrderCommand = new DelegateCommand(() =>
+            {
+                Comments = new ObservableCollection<Comment>(Comments.Reverse());
+                RaisePropertyChanged(nameof(Comments));
+            }));
+        }
 
         public DelegateCommand<string> ToggleVisibilityCommand => toggleVisibilityCommand ?? (toggleVisibilityCommand = new DelegateCommand<string>((string param) =>
         {

--- a/TimeStampNote/ViewModels/MainWindowViewModel.cs
+++ b/TimeStampNote/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Text.RegularExpressions;
     using Prism.Commands;
     using Prism.Mvvm;
@@ -23,8 +24,10 @@
         private DelegateCommand<string> toggleVisibilityCommand;
         private DelegateCommand toLigthThemeCommand;
         private DelegateCommand toDarkThemeCommand;
+        private DelegateCommand showSelectionCommentCommand;
 
         private string commandText = string.Empty;
+        private string statusBarText;
 
         public MainWindowViewModel()
         {
@@ -63,6 +66,8 @@
             get => commandText;
             set => SetProperty(ref commandText, value);
         }
+
+        public string StatusBarText { get => statusBarText; set => SetProperty(ref statusBarText, value); }
 
         public string Title
         {
@@ -225,6 +230,27 @@
                 UIColors.Theme = Theme.Dark;
                 Properties.Settings.Default.Theme = (int)Theme.Dark;
                 Properties.Settings.Default.Save();
+            }));
+        }
+
+        public DelegateCommand ShowSelectionCommentCommand
+        {
+            get => showSelectionCommentCommand ?? (showSelectionCommentCommand = new DelegateCommand(() =>
+            {
+                var selections = Comments.Where(cm => cm.IsSelected);
+
+                if (selections.Count() == 0)
+                {
+                    StatusBarText = string.Empty;
+                }
+                else if (selections.Count() == 1)
+                {
+                    StatusBarText = $"No. {selections.First().OrderNumber} ({selections.First().SubID}) を選択中";
+                }
+                else
+                {
+                    StatusBarText = $"{selections.Count()} 個のコメントを選択中";
+                }
             }));
         }
     }

--- a/TimeStampNote/Views/CustomStyleDictionary.xaml
+++ b/TimeStampNote/Views/CustomStyleDictionary.xaml
@@ -66,6 +66,7 @@
             <Setter.Value>
 
                 <Style TargetType="ListViewItem">
+                    <Setter Property="IsSelected" Value="{Binding IsSelected}" />
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type ContentControl}">

--- a/TimeStampNote/Views/MainWindow.xaml
+++ b/TimeStampNote/Views/MainWindow.xaml
@@ -35,6 +35,7 @@
                     <MenuItem Command="{Binding AddCommentCommand}" Header="Add" />
                     <MenuItem Command="{Binding AddGroupCommand}" Header="Add-Group" />
                     <MenuItem Header="edit &quot;subID&quot; " IsEnabled="False" />
+                    <MenuItem Header="delete &quot;subID&quot;" IsEnabled="False" />
 
                     <MenuItem
                         Command="{Binding ToggleVisibilityCommand}"

--- a/TimeStampNote/Views/MainWindow.xaml
+++ b/TimeStampNote/Views/MainWindow.xaml
@@ -36,6 +36,7 @@
                     <MenuItem Command="{Binding AddGroupCommand}" Header="Add-Group" />
                     <MenuItem Header="edit &quot;subID&quot; " IsEnabled="False" />
                     <MenuItem Header="delete &quot;subID&quot;" IsEnabled="False" />
+                    <MenuItem Command="{Binding ReverseOrderCommand}" Header="reverse-order" />
 
                     <MenuItem
                         Command="{Binding ToggleVisibilityCommand}"

--- a/TimeStampNote/Views/MainWindow.xaml
+++ b/TimeStampNote/Views/MainWindow.xaml
@@ -95,12 +95,20 @@
             Grid.Row="1"
             AlternationCount="2"
             Background="{Binding UIColors.DeepBackgroundColorBrush}"
-            ItemsSource="{Binding Comments}" />
+            ItemsSource="{Binding Comments}">
+
+            <i:Interaction.Triggers>
+                <i:EventTrigger EventName="SelectionChanged">
+                    <i:InvokeCommandAction Command="{Binding ShowSelectionCommentCommand}" />
+                </i:EventTrigger>
+            </i:Interaction.Triggers>
+
+        </ListView>
         <StatusBar
             Grid.Row="2"
             Background="{Binding UIColors.BackgroundColorBrush}"
             Foreground="{Binding UIColors.ForegroundColorBrush}">
-            <TextBlock Text="bottomStatusBar" />
+            <TextBlock Text="{Binding StatusBarText}" />
         </StatusBar>
 
     </Grid>

--- a/TimeStampNote/Views/MainWindow.xaml
+++ b/TimeStampNote/Views/MainWindow.xaml
@@ -36,6 +36,7 @@
                     <MenuItem Command="{Binding AddGroupCommand}" Header="Add-Group" />
                     <MenuItem Header="edit &quot;subID&quot; " IsEnabled="False" />
                     <MenuItem Header="delete &quot;subID&quot;" IsEnabled="False" />
+                    <MenuItem Header="set-order &quot;oldIndex&quot; &quot;newIndex&quot;" IsEnabled="False" />
                     <MenuItem Command="{Binding ReverseOrderCommand}" Header="reverse-order" />
 
                     <MenuItem


### PR DESCRIPTION
- add / Menu の項目に、削除コマンドの項を追加
- add / Comment が選択されているかを示すプロパティをビューとバインド
- add / 選択中のコメントの情報をステータスバーに表示するよう実装
- add / コメントの表示順を逆転する機能を実装
- add / Comment をグループ名、オーダーから取得するメソッドを追加
- add / コマンドからコメントの順番を変更する機能を実装
- add / メニューアイテムに set-order の記述を追加

close #5
